### PR TITLE
Fix run_tract_hunter dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,10 @@ Imports:
     sf,
     sfdep,
     shiny,
-    tigris
+    tigris,
+    glue,
+    igraph,
+    crayon
 Suggests: 
     knitr
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -15,6 +15,10 @@ importFrom(tigris, tracts)
 importFrom(sfdep, st_contiguity)
 importFrom(RColorBrewer, brewer.pal)
 importFrom(stringr, str_remove)
+importFrom(glue, glue)
+importFrom(igraph, graph_from_adj_list, graph_from_data_frame, k_shortest_paths,
+           components, induced_subgraph, articulation_points)
+importFrom(crayon, yellow)
 
 # mapgl - import the main functions you use
 importFrom(mapgl, maplibre, maplibreOutput, renderMaplibre, maplibre_proxy,


### PR DESCRIPTION
## Summary
- remove `library()` calls in `run_tract_hunter`
- use explicit namespace calls for glue, igraph, and crayon
- declare glue, igraph, and crayon dependencies
- register imported functions in NAMESPACE

## Testing
- `R -q -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a39ebb9b0832ab83296c8afad2dfd