### PR TITLE
Add pause feature for tract hunter

### DIFF
--- a/R/run_tract_hunter.R
+++ b/R/run_tract_hunter.R
@@ -22,15 +22,16 @@ run_tract_hunter <- function(tract_list,
   }
 
   check_pause <- function() {
-    if (requireNamespace("later", quietly = TRUE)) {
-      later::run_now(0)
-    }
-    while (isTRUE(pause())) {
-      if (requireNamespace("later", quietly = TRUE)) {
-        later::run_now(0.1)
-      } else {
-        Sys.sleep(0.1)
+    if (isTRUE(pause())) {
+      while (isTRUE(pause())) {
+        if (requireNamespace("later", quietly = TRUE)) {
+          later::run_now(0.1)
+        } else {
+          Sys.sleep(0.1)
+        }
       }
+    } else if (requireNamespace("later", quietly = TRUE)) {
+      later::run_now(0)
     }
   }
 

--- a/R/run_tract_hunter.R
+++ b/R/run_tract_hunter.R
@@ -6,7 +6,8 @@ run_tract_hunter <- function(tract_list,
                              ur_thresh  = 0.0645,
                              pop_thresh = 10000,
                              join_touching  = TRUE,   # <- NEW
-                             verbose    = TRUE) {
+                             verbose    = TRUE,
+                             pause      = function() FALSE) {
 
 
 
@@ -17,6 +18,16 @@ run_tract_hunter <- function(tract_list,
       shiny::incProgress(amount = 0, detail = msg)   # 0 ⇒ just change the text
     } else if (isTRUE(verbose)) {
       cat("\r", msg); flush.console()
+    }
+  }
+
+  check_pause <- function() {
+    while (isTRUE(pause())) {
+      if (requireNamespace("later", quietly = TRUE)) {
+        later::run_now(0.1)
+      } else {
+        Sys.sleep(0.1)
+      }
     }
   }
 
@@ -85,7 +96,8 @@ run_tract_hunter <- function(tract_list,
   }
 
   # ---- 1 · SEED‑AND‑EXPAND -------------------------------------------
-  repeat {
+  while (TRUE) {
+    check_pause()
     # 1) Identify all **unused** tracts with UR >= 0.0645
     all_unused <- setdiff(seq_along(ur_vec), used_indexes)
     valid_unused <- all_unused[ ur_vec[all_unused] >= .0645]
@@ -111,7 +123,8 @@ run_tract_hunter <- function(tract_list,
     # Tracts in this ASU
     asu_list <- c(starting_index)
 
-    repeat {
+    while (TRUE) {
+      check_pause()
 
       # 1) Identify the ASU boundary: any neighbor of asu_list that is not in asu_list or used_indexes
       boundary_tracts <- unique(unlist(nb[asu_list]))
@@ -549,7 +562,8 @@ run_tract_hunter <- function(tract_list,
 
   # ---- 2 · TRADE / MERGE PASSES ---------------------------------------
   asu_pass <- function(verbose = TRUE) {
-    repeat {
+    while (TRUE) {
+      check_pause()
       ## ---- 1. current state --------------------------------------
       data_merge_local <- data_merge      # it’s already in scope here
       # refresh

--- a/R/run_tract_hunter.R
+++ b/R/run_tract_hunter.R
@@ -22,6 +22,9 @@ run_tract_hunter <- function(tract_list,
   }
 
   check_pause <- function() {
+    if (requireNamespace("later", quietly = TRUE)) {
+      later::run_now(0)
+    }
     while (isTRUE(pause())) {
       if (requireNamespace("later", quietly = TRUE)) {
         later::run_now(0.1)
@@ -61,6 +64,7 @@ run_tract_hunter <- function(tract_list,
     all_paths <- list()
 
     while (length(queue) > 0) {
+      check_pause()
       current <- queue[[1]]
       queue <- queue[-1]
 
@@ -149,6 +153,7 @@ run_tract_hunter <- function(tract_list,
       best_pop   <- NA
 
       for (b in boundary_tracts) {
+        check_pause()
 
         # BFS or DFS up to 2 or 3 hops from b, ignoring asu_list & used_indexes
         candidate_paths <- bfs_paths_up_to_k_hops(start = b, nb = nb,
@@ -159,6 +164,7 @@ run_tract_hunter <- function(tract_list,
         # The last node in each path is the "far" neighbor.
 
         for (path_vec in candidate_paths) {
+          check_pause()
 
           # The set of new tracts if we add path_vec to the ASU
           # (We also include bridging tracts if they're in path_vec)
@@ -401,6 +407,7 @@ run_tract_hunter <- function(tract_list,
 
     # Iterate until the updated unemployment rate meets the threshold
     while(new_ur < 0.0645) {
+      check_pause()
       # Filter candidates based on whether their unemp is less than the unemp buffer
       drop_candidates <- drop_candidates[ unemp_vec[drop_candidates] < unemp_buffer ]
       if (length(drop_candidates) == 0) return(FALSE)
@@ -580,6 +587,7 @@ run_tract_hunter <- function(tract_list,
 
       ## ---- 2. loop over candidates ------------------------------
       for (i in seq_len(nrow(tracts_not_in_asu))) {
+        check_pause()
 
         target_index <- tracts_not_in_asu$row_num[i]
 

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -291,6 +291,15 @@ observeEvent(input$pause_hunter, {
   pause_flag(!pause_flag())
 })
 
+observe({
+  new_label <- if (isTRUE(pause_flag())) "Resume Tract Hunter" else "Pause Tract Hunter"
+  shiny::updateActionButton(
+    session = shiny::getDefaultReactiveDomain(),
+    inputId = "pause_hunter",
+    label   = new_label
+  )
+})
+
 observeEvent(input$process, {
 
   

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -76,6 +76,8 @@ map_data_dbg <- reactiveVal(NULL)   # container
 
 highlighted_tracts <- reactiveVal(character(0))
 
+pause_flag <- reactiveVal(FALSE)
+
 
 
 
@@ -215,6 +217,10 @@ conditionalPanel(
 
 
 actionButton("process", "Load Tracts and Initialize ASU")
+conditionalPanel(
+  condition = "input.asu_algo == 'mine'",
+  actionButton("pause_hunter", "Pause/Resume Tract Hunter")
+)
 # ---- dynamic algorithm description ------------------------------------
 output$algo_blurb <- renderUI({
 
@@ -281,6 +287,10 @@ uiOutput("algo_blurb")
 
 tableOutput("asu")
 
+observeEvent(input$pause_hunter, {
+  pause_flag(!pause_flag())
+})
+
 observeEvent(input$process, {
 
   
@@ -314,8 +324,9 @@ observeEvent(input$process, {
     } else {
       run_tract_hunter(
     tract_list, uploaded_data(),
-    join_touching = join_flag,   # ← this line makes the checkbox work again
-    verbose       = TRUE
+    join_touching = join_flag,
+    verbose       = TRUE,
+    pause         = function() pause_flag()
   )
     }
 

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -326,7 +326,7 @@ observeEvent(input$process, {
     tract_list, uploaded_data(),
     join_touching = join_flag,
     verbose       = TRUE,
-    pause         = function() pause_flag()
+    pause         = function() isolate(pause_flag())
   )
     }
 


### PR DESCRIPTION
## Summary
- allow pausing the tract hunter algorithm
- add pause button to Shiny dashboard
- switch algorithm loops from `repeat` to `while (TRUE)`
- support checking a reactive pause flag in `run_tract_hunter`

## Testing
- `apt-get update`
- `apt-get install -y r-base` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688a9381b43c832ab3ca66e55c931cba