### PR TITLE
Add staged Tract Hunter controls

### DIFF
--- a/R/run_tract_hunter.R
+++ b/R/run_tract_hunter.R
@@ -1,31 +1,32 @@
 # -----------------------------------------------------------------------
 # run_tract_hunter.R  –  “as‑is” port of your original script
 # -----------------------------------------------------------------------
-run_tract_hunter <- function(tract_list,
-                             bls_df,
-                             ur_thresh  = 0.0645,
-                             pop_thresh = 10000,
-                             join_touching  = TRUE,   # <- NEW
-                             verbose    = TRUE) {
 
+# The functions below break the Tract Hunter algorithm into
+# discrete stages so the Shiny dashboard can run each step
+# individually.  `run_tract_hunter()` still executes the full
+# pipeline for backwards compatibility.
 
+tract_hunter_seed <- function(tract_list,
+                              bls_df,
+                              ur_thresh  = 0.0645,
+                              pop_thresh = 10000,
+                              verbose    = TRUE) {
 
-  # --- progress helper ---------------------------------------------------
   update_status <- function(msg) {
-    # If we're running inside a Shiny session *and* inside a withProgress block
     if (requireNamespace("shiny", quietly = TRUE) && shiny::isRunning()) {
-      shiny::incProgress(amount = 0, detail = msg)   # 0 ⇒ just change the text
+      shiny::incProgress(amount = 0, detail = msg)
     } else if (isTRUE(verbose)) {
       cat("\r", msg); flush.console()
     }
   }
 
-
-  # ---- 0 · PREP --------------------------------------------------------
+  # ---- 0 · PREP ----------------------------------------------------
   data_merge <- tract_list %>%
     left_join(bls_df, by = "GEOID") %>%
     mutate(
-      ur      = ifelse(tract_ASU_unemp+tract_ASU_emp ==0, 0, tract_ASU_unemp/(tract_ASU_unemp+tract_ASU_emp)),
+      ur      = ifelse(tract_ASU_unemp + tract_ASU_emp == 0,
+                        0, tract_ASU_unemp/(tract_ASU_unemp + tract_ASU_emp)),
       row_num = if_else(!is.na(row_num), row_num, row_number())
     )
 
@@ -41,56 +42,36 @@ run_tract_hunter <- function(tract_list,
   tried_starting_indexes <- integer(0)
   asu_groups             <- list()
 
-  # ---- 1 · SEED‑AND‑EXPAND -------------------------------------------
+  # ---- 1 · SEED‑AND‑EXPAND ---------------------------------------
   repeat {
-    # 1) Identify all **unused** tracts with UR above threshold
-    all_unused <- setdiff(seq_along(ur_vec), used_indexes)
-    valid_unused <- all_unused[ ur_vec[all_unused] >= ur_thresh]
+    all_unused   <- setdiff(seq_along(ur_vec), used_indexes)
+    valid_unused <- all_unused[ ur_vec[all_unused] >= ur_thresh ]
 
-    # Exclude any that we already tried as a starting point
     possible_starts <- setdiff(valid_unused, tried_starting_indexes)
+    if (length(possible_starts) == 0) break
 
-    # If none remain, we're done
-    if (length(possible_starts) == 0) {
-      # message("No more possible starting tracts meeting UR threshold that haven't been tried.")
-      break
-    }
-
-    # 2) Pick the starting tract with the highest unemployment among possible_starts
     starting_index <- possible_starts[which.max(ur_vec[possible_starts])]
 
-    # Initialize metrics for the new ASU
     asu_emp   <- emp_vec[starting_index]
     asu_unemp <- unemp_vec[starting_index]
     asu_pop   <- population_vec[starting_index]
-    asu_ur    <- ifelse(asu_emp+asu_unemp == 0, 0, asu_unemp / (asu_emp + asu_unemp))
+    asu_ur    <- ifelse(asu_emp + asu_unemp == 0,
+                         0, asu_unemp / (asu_emp + asu_unemp))
 
-    # Tracts in this ASU
     asu_list <- c(starting_index)
 
     repeat {
-
-      # 1) Identify the ASU boundary: any neighbor of asu_list that is not in asu_list or used_indexes
       boundary_tracts <- unique(unlist(nb[asu_list]))
       boundary_tracts <- setdiff(boundary_tracts, c(asu_list, used_indexes))
+      if (length(boundary_tracts) == 0) break
 
-      # If no boundary remains, we can't expand
-      if (length(boundary_tracts) == 0) {
-        # message("No boundary tracts remain; can't expand further.")
-        break
-      }
-
-      # 2) Evaluate boundary tracts using Rcpp helper to avoid BFS overhead
       res <- choose_best_neighbor(boundary_tracts,
                                   emp_vec, unemp_vec, population_vec,
                                   asu_emp, asu_unemp, asu_pop,
                                   ur_thresh)
 
       best_index <- res$best_index
-
-      if (is.na(best_index)) {
-        break
-      }
+      if (is.na(best_index)) break
 
       best_path  <- best_index
       best_ur    <- res$best_ur
@@ -98,179 +79,174 @@ run_tract_hunter <- function(tract_list,
       best_unemp <- res$best_unemp
       best_pop   <- res$best_pop
 
-      # Otherwise, add all bridging tracts in best_path to the ASU
       new_tracts <- setdiff(best_path, asu_list)
       asu_list   <- c(asu_list, new_tracts)
 
-      # Update your metrics
       asu_emp    <- best_emp
       asu_unemp  <- best_unemp
       asu_pop    <- best_pop
       asu_ur     <- best_ur
 
       cat(glue::glue("UR: {round(asu_ur, 4)} | Unemp: {round(asu_unemp)} | Emp: {round(asu_emp)} | Pop: {round(asu_pop)}   \r"))
-      flush.console()  # Especially important in RGui or RStudio
-
-
-      # (loop repeats, looking for the next set of bridging expansions)
+      flush.console()
     }
 
-    # ---------------------------------------------------------------------
-    # 4) Check final criteria for this ASU (pop >= 10000, UR >= threshold)
-    # ---------------------------------------------------------------------
     if (asu_pop >= pop_thresh && asu_ur >= ur_thresh) {
-      # It's a valid ASU; save it and mark these tracts used
       asu_groups[[length(asu_groups) + 1]] <- asu_list
       used_indexes <- c(used_indexes, asu_list)
-      # message(glue("Valid ASU created. pop={asu_pop}, UR={asu_ur}"))
     } else {
-      # Not valid -> record that we tried this start and skip it next time
       tried_starting_indexes <- c(tried_starting_indexes, starting_index)
-      # message(glue(
-      #   "ASU not valid. pop={asu_pop}, UR={asu_ur}. Marking tract {starting_index} as tried."
-      # ))
     }
   }
-
-
 
   data_merge$asunum <- NA
   for (i in seq_along(asu_groups)) {
-    # Each asu_groups[[i]] is a vector of tract row indices in data_merge
     group_rows <- asu_groups[[i]]
-
-    # Assign ASU number `i` to these rows
     data_merge$asunum[group_rows] <- i
   }
 
-  # ---- helpers for trade / merge (identical to original) --------------
-  unemployment_rate <- function(indexes){
-    return(sum(unemp_vec[indexes])/(sum(emp_vec[indexes])+sum(unemp_vec[indexes])))
+  list(
+    data_merge      = data_merge,
+    nb              = nb,
+    g               = g,
+    emp_vec         = emp_vec,
+    unemp_vec       = unemp_vec,
+    population_vec  = population_vec,
+    ur_vec          = ur_vec,
+    ur_thresh       = ur_thresh,
+    pop_thresh      = pop_thresh
+  )
+}
+
+combine_asu_groups_internal <- function(tract_data, nb) {
+  assigned <- tract_data %>% filter(!is.na(asunum))
+  asu_vec  <- as.integer(tract_data$asunum)
+  edges_mat <- build_asu_edges(nb, asu_vec)
+
+  if (nrow(edges_mat) == 0) {
+    message("No ASU groups are touching; no merging required.")
+    return(tract_data)
+  } else {
+    edges_unique <- unique(t(apply(edges_mat, 1, sort)))
+
+    asunums <- unique(assigned$asunum)
+    vertices_df <- data.frame(name = asunums, stringsAsFactors = FALSE)
+
+    asu_graph <- igraph::graph_from_data_frame(
+      d = as.data.frame(edges_unique, stringsAsFactors = FALSE),
+      vertices = vertices_df,
+      directed = FALSE
+    )
+
+    comps <- igraph::components(asu_graph)
+
+    lookup <- data.frame(
+      original_asu = names(comps$membership),
+      comp = comps$membership,
+      stringsAsFactors = FALSE
+    )
+
+    new_ids <- lookup %>%
+      group_by(comp) %>%
+      summarize(new_asu = min(original_asu)) %>%
+      ungroup()
+
+    lookup <- lookup %>% left_join(new_ids, by = "comp")
+
+    tract_data <- tract_data %>%
+      mutate(asunum = ifelse(!is.na(asunum),
+                             lookup$new_asu[match(as.character(asunum), lookup$original_asu)],
+                             asunum))
+
+    message(crayon::yellow("Combined ASU groups based on touching tracts."))
+    return(tract_data)
+  }
+}
+
+tract_hunter_asu_pass <- function(state, verbose = TRUE) {
+
+  data_merge <- state$data_merge
+  nb         <- state$nb
+  g          <- state$g
+  emp_vec    <- state$emp_vec
+  unemp_vec  <- state$unemp_vec
+  ur_thresh  <- state$ur_thresh
+
+  update_status <- function(msg) {
+    if (requireNamespace("shiny", quietly = TRUE) && shiny::isRunning()) {
+      shiny::incProgress(amount = 0, detail = msg)
+    } else if (isTRUE(verbose)) {
+      cat("\r", msg); flush.console()
+    }
   }
 
+  unemployment_rate <- function(indexes){
+    sum(unemp_vec[indexes])/(sum(emp_vec[indexes])+sum(unemp_vec[indexes]))
+  }
 
   find_boundary_path <- function(target_index, asu_indexes) {
-    # --- Step 1: Find the asu neighbor(s) ---
 
-    # Get direct neighbors of the target tract.
     current_neighbors <- unlist(nb[target_index])
-    # Check if any direct neighbor is in asu_indexes.
     found_neighbors <- current_neighbors[current_neighbors %in% asu_indexes]
 
-    # If no direct neighbors are in asu_indexes, iteratively expand.
     if (length(found_neighbors) == 0) {
-      # Initialize a vector of visited nodes to avoid re-expanding the same nodes.
       visited <- target_index
-      # Set current level to the direct neighbors of target.
       current_level <- current_neighbors
-
-      # Iteratively expand until at least one neighbor in asu_indexes is found.
       while (length(found_neighbors) == 0 && length(current_level) > 0) {
-        # Mark these nodes as visited.
         visited <- c(visited, current_level)
-
-        # Expand: get neighbors for all nodes in the current level.
         next_level <- unique(unlist(nb[current_level]))
-
-        # Remove nodes that have already been visited.
         next_level <- setdiff(next_level, visited)
-
-        # Check if any of the new nodes are in asu_indexes.
         found_neighbors <- next_level[next_level %in% asu_indexes]
-
-        # Update current_level.
         current_level <- next_level
       }
     }
 
-    asu_emp <- sum(emp_vec[asu_indexes])
+    asu_emp   <- sum(emp_vec[asu_indexes])
     asu_unemp <- sum(unemp_vec[asu_indexes])
 
-    # valid_neighbors <- c()
-    # for (neighbor in found_neighbors){
-    #   neighbor_ur <- unemployment_rate(c(neighbor,target_index))
-    #
-    #   valid_neighbors <- c(valid_neighbors,neighbor_ur)
-    # }
-    #
-    # optimal_neighbor <- found_neighbors[which.max(valid_neighbors)]
-
-
-    # Display the found neighbors in asu_indexes (for diagnostic purposes).
-    #cat("Found neighbor(s) in asu_indexes:", found_neighbors, "\n")
-
-    # --- Step 2: Find All Simple Paths ---
-    # Using igraph's all_simple_paths() to get all paths from each found neighbor to the target.
-    all_paths <- list()  # container for candidate paths
+    all_paths <- list()
     for (nbr in found_neighbors) {
-      # Using a cutoff (here 5) to limit path length. Adjust the cutoff as needed.
       paths_temp <- igraph::k_shortest_paths(g, from = nbr, to = target_index, mode = "out", k = 5)
       all_paths <- c(all_paths, paths_temp$vpath)
     }
 
-
-
-    # --- Step 3: Compute the Candidate Unemployment Ratio for Each Path ---
-    cands_ur <- c()  # container for candidate unemployment rates
+    cands_ur <- c()
     for (path in all_paths) {
-      # Convert vertex sequence to a vector of vertex IDs
       path_ids <- as.numeric(path)
-      # Remove asu indexes from the path
       new_tracts <- setdiff(path_ids, asu_indexes)
-
-      # Compute the unemployment rate for the path.
-      # (Assumes unemp_vec and emp_vec have been defined and are indexed similarly to the graph.)
-      path_ur <- (sum(unemp_vec[new_tracts])+asu_unemp) / (sum(unemp_vec[new_tracts]) + sum(emp_vec[new_tracts])+asu_emp+asu_unemp)
-
+      path_ur <- (sum(unemp_vec[new_tracts]) + asu_unemp) /
+        (sum(unemp_vec[new_tracts]) + sum(emp_vec[new_tracts]) + asu_emp + asu_unemp)
       cands_ur <- c(cands_ur, path_ur)
     }
 
-    # Check if any paths were found.
-    if (length(cands_ur) == 0) {
-      #stop("No candidate paths found that connect the target to asu_indexes")
-      break
-    }
+    if (length(cands_ur) == 0) break
 
-    # Get the full path (as a vertex sequence) corresponding to the maximum unemployment ratio.
     full_path_to_target <- all_paths[[which.max(cands_ur)]]
 
-    # Return the set difference between the full path and asu_indexes.
-    result <- list(
+    list(
       new_tracts = setdiff(as.numeric(full_path_to_target), asu_indexes),
-      neighbors = found_neighbors,
-      full_path = full_path_to_target
+      neighbors  = found_neighbors,
+      full_path  = full_path_to_target
     )
-    return(result)
   }
 
   update_tract_data <- function(target_index) {
-    # 1. Use base R indexing to get all asu indexes (non-NA)
     all_asu_indexes <- which(!is.na(data_merge$asunum))
 
-    # 2. Find the boundary path using your helper
-    # (Assuming data_merge$index contains numeric indexes)
     path_finder <- find_boundary_path(target_index, asu_indexes = data_merge$row_num[all_asu_indexes])
-    new_indexes <- path_finder$new_tracts
+    new_indexes  <- path_finder$new_tracts
 
-    # 3. Determine the ASU being processed from the boundary path (using the first entry)
     asu_being_processed <- data_merge$asunum[as.numeric(path_finder$full_path[[1]])]
-
-    # 4. Gather all indexes for the current ASU using base R filtering
     asu_indexes <- which(data_merge$asunum == asu_being_processed)
 
-    # 5. Create the union and induced subgraph (compute once)
     union_indexes <- sort(c(asu_indexes, new_indexes))
     sub_g <- igraph::induced_subgraph(g, vids = union_indexes)
-
-    # 6. Get cut vertices from subgraph and compute invalid drop ids
     cp <- igraph::articulation_points(sub_g)
     cut_verts <- if (length(cp) > 0) union_indexes[cp] else integer(0)
     invalid_drop_ids <- c(cut_verts, new_indexes)
 
-    # 7. Determine drop candidates (asu_indexes not on the boundary or among new_indexes)
     drop_candidates <- setdiff(asu_indexes, invalid_drop_ids)
 
-    # 8. Set the initial remaining indexes and precompute sums
     remaining_indexes <- asu_indexes
     total_new_unemp <- sum(unemp_vec[new_indexes], na.rm = TRUE)
     total_new_emp   <- sum(emp_vec[new_indexes],   na.rm = TRUE)
@@ -280,90 +256,54 @@ run_tract_hunter <- function(tract_list,
     new_ur <- (remaining_unemp + total_new_unemp) /
       (remaining_unemp + total_new_unemp + remaining_emp + total_new_emp)
 
-    # 9. Early exit: if the new rate is already acceptable, update and return TRUE.
     if (new_ur >= ur_thresh) {
       flush.console()
-      # cat(green(glue::glue("\n Adding in {toString(new_indexes)}, no trade needed.\n Added {sum(unemp_vec[new_indexes])} unemp \n")))
-      # flush.console()
       data_merge[new_indexes, "asunum"] <<- asu_being_processed
       return(TRUE)
     }
 
-    # 10. Initialize iterative dropping process
     dropped_indexes <- integer(0)
-    trade_complete <- FALSE
-    unemp_buffer <- total_new_unemp  # Total unemp being added
+    trade_complete  <- FALSE
+    unemp_buffer    <- total_new_unemp
 
-    # Iterate until the updated unemployment rate meets the threshold
-    while(new_ur < ur_thresh) {
-      # Filter candidates based on whether their unemp is less than the unemp buffer
+    while (new_ur < ur_thresh) {
       drop_candidates <- drop_candidates[ unemp_vec[drop_candidates] < unemp_buffer ]
       if (length(drop_candidates) == 0) return(FALSE)
 
-      # Choose the drop candidate that maximizes UR via Rcpp
       drop_res <- choose_best_drop_candidate(drop_candidates,
                                              unemp_vec, emp_vec,
                                              remaining_unemp, remaining_emp,
                                              total_new_unemp, total_new_emp,
                                              unemp_buffer)
       new_drop_index <- drop_res$best_index
-
       if (is.na(new_drop_index)) return(FALSE)
 
-      # Update: add candidate to dropped_indexes and remove it from remaining_indexes
-      dropped_indexes <- c(dropped_indexes, new_drop_index)
+      dropped_indexes  <- c(dropped_indexes, new_drop_index)
       remaining_indexes <- setdiff(remaining_indexes, new_drop_index)
+      remaining_unemp   <- remaining_unemp - unemp_vec[new_drop_index]
+      remaining_emp     <- remaining_emp   - emp_vec[new_drop_index]
 
-      remaining_unemp <- remaining_unemp - unemp_vec[new_drop_index]
-      remaining_emp   <- remaining_emp   - emp_vec[new_drop_index]
+      if (sum(unemp_vec[dropped_indexes], na.rm = TRUE) > unemp_buffer) return(FALSE)
 
-      # Safety check: if dropped too much, break out
-      if(sum(unemp_vec[dropped_indexes], na.rm = TRUE) > unemp_buffer) return(FALSE)
-
-      # Recalculate new unemployment rate
       new_ur <- (remaining_unemp + total_new_unemp) /
         (remaining_unemp + total_new_unemp + remaining_emp + total_new_emp)
 
-      # Compute improvement and current combined unemployment level
-      current_improvement <- total_new_unemp - sum(unemp_vec[dropped_indexes], na.rm = TRUE)
-      current_total_unemp <- remaining_unemp + total_new_unemp
-
-      # Report status after candidate drop
-      # status_msg <- glue::glue("Dropped candidate {new_drop_index} | Improvement so far: {current_improvement} | Combined Unemp: {current_total_unemp} | New UR: {round(new_ur, 4)}")
-      # cat(green(status_msg), "\n")
-      # flush.console()
-
-      if(new_ur >= ur_thresh) {
-        # cat("Hooray!\n")
-        # flush.console()
+      if (new_ur >= ur_thresh) {
         trade_complete <- TRUE
         break
       }
 
-      # Update drop candidates: recompute subgraph and invalid drop ids
       union_indexes <- sort(c(remaining_indexes, new_indexes))
       sub_g <- igraph::induced_subgraph(g, vids = union_indexes)
       cp <- igraph::articulation_points(sub_g)
-      cut_verts <- if(length(cp) > 0) union_indexes[cp] else integer(0)
+      cut_verts <- if (length(cp) > 0) union_indexes[cp] else integer(0)
       invalid_drop_ids <- c(cut_verts, new_indexes)
       drop_candidates <- setdiff(remaining_indexes, invalid_drop_ids)
-
-      # Filter drop candidates again
       drop_candidates <- drop_candidates[ unemp_vec[drop_candidates] < unemp_buffer ]
       if (length(drop_candidates) == 0) return(FALSE)
     }
 
-    # 11. Finalize the update if the trade succeeded
-    if(trade_complete) {
-      improvement <- total_new_unemp - sum(unemp_vec[dropped_indexes], na.rm = TRUE)
-      # Clear the line with a newline, ensuring you’re on a new line:
-      # cat("\n\r")
-      # flush.console()
-      # cat(green(glue::glue("\nTrade Complete, adding {toString(new_indexes)} and dropping {toString(dropped_indexes)} ")))
-      # cat(green(glue::glue(" Improved unemp by {improvement}\n")))
-      # flush.console()
-
-
+    if (trade_complete) {
       data_merge[dropped_indexes, "asunum"] <<- NA_character_
       data_merge[new_indexes, "asunum"] <<- asu_being_processed
       return(TRUE)
@@ -372,152 +312,67 @@ run_tract_hunter <- function(tract_list,
     }
   }
 
-  combine_asu_groups <- function(tract_data, nb) {
+  repeat {
+    data_merge_local <- data_merge
+    tracts_not_in_asu <- data_merge_local %>%
+      filter(is.na(asunum)) %>%
+      arrange(-ur)
 
-    # ------------------------------------------------
-    # STEP 1: Build an edge list between ASUs based on touching tracts.
-    # ------------------------------------------------
-
-    # Filter to tracts that are assigned to an ASU
-    assigned <- tract_data %>% filter(!is.na(asunum))
-    asu_vec <- as.integer(tract_data$asunum)
-    edges_mat <- build_asu_edges(nb, asu_vec)
-
-    if (nrow(edges_mat) == 0) {
-      message("No ASU groups are touching; no merging required.")
-      return(tract_data)
-    } else {
-      edges_unique <- unique(t(apply(edges_mat, 1, sort)))
-
-      # ------------------------------------------------
-      # STEP 2: Build the ASU graph and compute connected components.
-      # ------------------------------------------------
-      asunums <- unique(assigned$asunum)
-      # Create the vertex data frame with a "name" column
-      vertices_df <- data.frame(name = asunums, stringsAsFactors = FALSE)
-
-      asu_graph <- igraph::graph_from_data_frame(
-        d = as.data.frame(edges_unique, stringsAsFactors = FALSE),
-        vertices = vertices_df,
-        directed = FALSE
-      )
-
-      comps <- igraph::components(asu_graph)
-
-      # Create a lookup table mapping the original asunum to the new combined asunum.
-      lookup <- data.frame(
-        original_asu = names(comps$membership),
-        comp = comps$membership,
-        stringsAsFactors = FALSE
-      )
-      # For each component choose the smallest original asu id as the new id.
-      new_ids <- lookup %>%
-        group_by(comp) %>%
-        summarize(new_asu = min(original_asu)) %>%
-        ungroup()
-
-      lookup <- lookup %>% left_join(new_ids, by = "comp")
-
-      # ------------------------------------------------
-      # STEP 3: Update tract_data so that each tract gets the combined asunum.
-      # ------------------------------------------------
-      tract_data <- tract_data %>%
-        mutate(asunum = ifelse(!is.na(asunum),
-                               lookup$new_asu[match(as.character(asunum), lookup$original_asu)],
-                               asunum))
-
-      message(crayon::yellow("Combined ASU groups based on touching tracts."))
-      return(tract_data)
+    if (nrow(tracts_not_in_asu) == 0L) {
+      if (verbose) cat("\nNo more tracts to process.\n")
+      break
     }
-  }
 
-  # ---- 2 · TRADE / MERGE PASSES ---------------------------------------
-  asu_pass <- function(verbose = TRUE) {
-    repeat {
-      ## ---- 1. current state --------------------------------------
-      data_merge_local <- data_merge      # it’s already in scope here
-      # refresh
-      tracts_not_in_asu <- data_merge_local %>%
-        filter(is.na(asunum)) %>%
-        arrange(-ur)
+    successful_update <- FALSE
+    n_can <- nrow(tracts_not_in_asu)
 
-      if (nrow(tracts_not_in_asu) == 0L) {
-        if (verbose) cat("\nNo more tracts to process.\n")
-        break
+    for (i in seq_len(n_can)) {
+      target_index <- tracts_not_in_asu$row_num[i]
+
+      ok <- update_tract_data(target_index)
+
+      data_merge_local <- data_merge
+      tracts_in_asu    <- data_merge_local$row_num[!is.na(data_merge_local$asunum)]
+      unemp_tot        <- sum(unemp_vec[tracts_in_asu])
+
+      if (verbose && (i %% 500L == 1L || i == n_can)) {
+        update_status(
+          glue::glue("Targeting: {target_index} | Remaining: {n_can - i} | Unemployed: {unemp_tot}")
+        )
       }
 
-      successful_update <- FALSE
-
-      ## ---- 2. loop over candidates ------------------------------
-      n_can <- nrow(tracts_not_in_asu)          # cache once
-
-      for (i in seq_len(n_can)) {
-
-        target_index <- tracts_not_in_asu$row_num[i]
-
-        ## run the user-supplied updater  (works by side-effect on global data_merge)
-        ok <- update_tract_data(target_index)
-
-        ## refresh state **after** possible change
-        data_merge_local <- data_merge
-        tracts_in_asu    <- data_merge_local$row_num[!is.na(data_merge_local$asunum)]
-        unemp_tot        <- sum(unemp_vec[tracts_in_asu])
-
-        ## show progress only every 100th iteration (and on the very last one)
-        if (verbose && (i %% 500L == 1L || i == n_can)) {
-          update_status(
-            glue::glue("Targeting: {target_index} | Remaining: {n_can - i} | Unemployed: {unemp_tot}")
-          )
-        }
-
-        if (isTRUE(ok)) {        # update succeeded
-          successful_update <- TRUE
-          break                 # start a fresh repeat cycle
-        }
-      }
-
-      ## ---- 3. nothing worked this pass --------------------------
-      if (!successful_update) {
-        if (verbose) cat("\nNone of the target indexes produced an update. Exiting loop.\n")
+      if (isTRUE(ok)) {
+        successful_update <- TRUE
         break
       }
     }
+
+    if (!successful_update) {
+      if (verbose) cat("\nNone of the target indexes produced an update. Exiting loop.\n")
+      break
+    }
   }
 
-  ##### ---- 2 · INITIALIZE ASU NUMBERS -----------------------------------
+  state$data_merge <- data_merge
+  state
+}
 
-  # 0. make sure asunum is character
-  data_merge <- data_merge %>%
-    mutate(asunum = as.character(asunum))
+tract_hunter_combine_groups <- function(state) {
+  state$data_merge <- combine_asu_groups_internal(state$data_merge, state$nb)
+  state
+}
 
-  # 1st pass
-  asu_pass(verbose = TRUE)
+tract_hunter_finalize <- function(state) {
+  data_merge <- state$data_merge
+  unemp_vec  <- state$unemp_vec
 
-  # optionally merge touching ASUs  -------------------------------
-  if (isTRUE(join_touching)) {
-    data_merge <- combine_asu_groups(data_merge, nb)
-
-    # 2nd pass
-    asu_pass(verbose = TRUE)
-  }
-
-
-  # final report
-  cat(
-    "\nFinal unemployment total: ",
-    sum(unemp_vec[data_merge$row_num[!is.na(data_merge$asunum)]], na.rm = TRUE),
-    "\n"
-  )
-
-
-  # ---- 3 · RETURN OBJECTS --------------------------------------------
   data_merge$asunum[is.na(data_merge$asunum)] <- 0
 
   full_data <- data_merge %>%
     select(-continuous) %>%
     st_as_sf() %>%
     st_cast("MULTIPOLYGON", warn = FALSE) %>%
-    mutate(ur = ur*100,
+    mutate(ur = ur * 100,
            asunum = as.integer(asunum))
 
   asu_tracts <- full_data %>% filter(asunum > 0)
@@ -541,4 +396,25 @@ run_tract_hunter <- function(tract_list,
     full_data_reset = full_data,
     asu_data        = asu_tracts
   )
+}
+
+run_tract_hunter <- function(tract_list,
+                             bls_df,
+                             ur_thresh  = 0.0645,
+                             pop_thresh = 10000,
+                             join_touching = TRUE,
+                             verbose    = TRUE) {
+  state <- tract_hunter_seed(tract_list, bls_df,
+                             ur_thresh = ur_thresh,
+                             pop_thresh = pop_thresh,
+                             verbose = verbose)
+
+  state <- tract_hunter_asu_pass(state, verbose = verbose)
+
+  if (isTRUE(join_touching)) {
+    state <- tract_hunter_combine_groups(state)
+    state <- tract_hunter_asu_pass(state, verbose = verbose)
+  }
+
+  tract_hunter_finalize(state)
 }

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -77,6 +77,11 @@ edit_table <- reactiveVal(NULL)
 edit_summary <- reactiveVal(NULL)
 current_selection <- reactiveVal(NULL)
 
+# Tract Hunter staged state -----------------------------------------
+th_state <- reactiveVal(NULL)
+th_tract_list <- reactiveVal(NULL)
+th_bls_df <- reactiveVal(NULL)
+
 map_data_dbg <- reactiveVal(NULL)   # container
 
 highlighted_tracts <- reactiveVal(character(0))
@@ -218,6 +223,13 @@ conditionalPanel(
                 value = TRUE)
 )
 
+conditionalPanel(
+  condition = "input.asu_algo == 'mine'",
+  actionButton("th_seed", "Seed & Expand"),
+  actionButton("th_pass", "Run ASU Pass"),
+  actionButton("th_combine", "Combine ASU Groups")
+)
+
 
 actionButton("process", "Load Tracts and Initialize ASU")
 # ---- dynamic algorithm description ------------------------------------
@@ -314,14 +326,13 @@ observeEvent(input$process, {
     join_flag <- isTRUE(input$join_touching)   # ← keep the flag you already built
     
     incProgress(0.05, detail = "Finding initial ASU seeds…")
-    res <- if (algo_choice == "orig") {
-      run_asu_original(tract_list, uploaded_data())      # <- no verbose here
+    if (algo_choice == "orig") {
+      res <- run_asu_original(tract_list, uploaded_data())
     } else {
-      run_tract_hunter(
-    tract_list, uploaded_data(),
-    join_touching = join_flag,   # ← this line makes the checkbox work again
-    verbose       = TRUE
-  )
+      th_tract_list(tract_list)
+      th_bls_df(uploaded_data())
+      th_state(NULL)
+      res <- NULL
     }
 
 
@@ -330,13 +341,14 @@ observeEvent(input$process, {
   })  # ---- withProgress ends here  -------------------------------------
 
   ## 4 · Store results & draw map  --------------------------------------
-  full_data(res$full_data  )   ; full_data_reset(res$full_data_reset)
-  asu_data(res$asu_data    )   ; asu_tracts(res$asu_tracts)
-  asu_summary(res$asu_summary) ; map_data_dbg(res$full_data)
+  if (!is.null(res)) {
+    full_data(res$full_data  )   ; full_data_reset(res$full_data_reset)
+    asu_data(res$asu_data    )   ; asu_tracts(res$asu_tracts)
+    asu_summary(res$asu_summary) ; map_data_dbg(res$full_data)
 
-  output$asu <- renderTable( asu_summary(),digits = 3 )
-  
-  ## 5. (Re‑)draw the first map ----------------------------------
+    output$asu <- renderTable( asu_summary(),digits = 3 )
+
+    ## 5. (Re‑)draw the first map ----------------------------------
 
   output$initial_map <- renderMaplibre({
 
@@ -435,7 +447,194 @@ observeEvent(input$process, {
       )
   })
 
+}
+
 })  # ---- end observeEvent -------------------------------------------------
+
+# ---- staged Tract Hunter buttons ---------------------------------------
+observeEvent(input$th_seed, {
+  req(th_tract_list(), th_bls_df())
+  withProgress(message = "Seeding & expanding…", value = 0, {
+    st <- tract_hunter_seed(th_tract_list(), th_bls_df(), verbose = TRUE)
+  })
+  th_state(st)
+  res <- tract_hunter_finalize(st)
+  full_data(res$full_data  )   ; full_data_reset(res$full_data_reset)
+  asu_data(res$asu_data    )   ; asu_tracts(res$asu_tracts)
+  asu_summary(res$asu_summary) ; map_data_dbg(res$full_data)
+  output$asu <- renderTable( asu_summary(),digits = 3 )
+  output$initial_map <- renderMaplibre({
+    req(full_data())
+    map_data <- full_data()
+    map_data <- map_data |>
+      sf::st_make_valid() |>
+      sf::st_zm(what = "ZM", drop = TRUE) |>
+      dplyr::filter(!sf::st_is_empty(geometry)) |>
+      dplyr::mutate(geom_type = sf::st_geometry_type(geometry)) |>
+      dplyr::filter(geom_type %in% c("POLYGON", "MULTIPOLYGON")) |>
+      dplyr::select(-geom_type)
+    if (nrow(map_data) == 0) {
+      return(
+        maplibre(style = carto_style("positron")) |>
+        add_control("No valid polygon geometry to display.", "top-left")
+      )
+    }
+    map_data <- map_data |>
+      dplyr::mutate(asunum = dplyr::na_if(asunum, 0L))
+    n_asu <- max(map_data$asunum, na.rm = TRUE)
+    n_asu <- ifelse(is.finite(n_asu), n_asu, 0L)
+    palette_logic <- function(n_asu) {
+  if (n_asu == 0) {
+    list(fill = "#808080",
+         legend_vals = "(none)",
+         legend_cols = "#808080")
+
+  } else if (n_asu == 1) {
+    list(
+      fill  = step_expr(column="asunum",
+                        base="#808080",
+                        stops="#7FC97F",
+                        values=1,
+                        na_color="#444444"),
+      legend_vals = 1,
+      legend_cols = "#7FC97F"
+    )
+
+  } else {
+    n_cat <- min(max(n_asu, 3L), 8L)
+    pal   <- RColorBrewer::brewer.pal(n_cat, "Accent")
+    legend_cols <- rep_len(pal, n_asu)
+    breaks <- seq(1 + n_asu / n_cat, n_asu, length.out = n_cat - 1)
+    list(
+      fill = step_expr(column   = "asunum",
+                       base     = pal[1],
+                       stops    = pal[-1],
+                       values   = breaks,
+                       na_color = "#444444"),
+      legend_vals = seq_len(n_asu),
+      legend_cols = legend_cols
+    )
+  }
+}
+    pal <- palette_logic(n_asu)
+    maplibre(style = carto_style("positron")) |>
+      fit_bounds(map_data, animate = FALSE) |>
+      add_fill_layer(
+        id                 = "basemap",
+        source             = map_data,
+        fill_color         = pal$fill,
+        fill_opacity       = 0.5,
+        fill_outline_color = "black",
+        popup = concat(
+          "<strong>ASU Number: </strong>", get_column("asunum"), "<br>",
+          "<strong>Tract GEOID: </strong>", get_column("GEOID"),  "<br>",
+          "<strong>UR: </strong>",
+          number_format(get_column("tract_ASU_urate"),
+                        style = "decimal", maximum_fraction_digits = 2),
+          "%<br>",
+          "<strong>Unemp: </strong>",
+          number_format(get_column("tract_ASU_unemp"),
+                        style = "decimal", maximum_fraction_digits = 0), "<br>"
+        )
+      ) |>
+      add_legend(
+        "ASU Number",
+        values = pal$legend_vals,
+        colors = pal$legend_cols,
+        type   = "categorical"
+      )
+  })
+})
+
+observeEvent(input$th_pass, {
+  req(th_state())
+  withProgress(message = "Running ASU pass…", value = 0, {
+    st <- tract_hunter_asu_pass(th_state(), verbose = TRUE)
+  })
+  th_state(st)
+  res <- tract_hunter_finalize(st)
+  full_data(res$full_data  )   ; full_data_reset(res$full_data_reset)
+  asu_data(res$asu_data    )   ; asu_tracts(res$asu_tracts)
+  asu_summary(res$asu_summary) ; map_data_dbg(res$full_data)
+  output$asu <- renderTable( asu_summary(),digits = 3 )
+  maplibre_proxy("initial_map") %>% clear_layer("basemap")
+  output$initial_map <- renderMaplibre({
+    req(full_data())
+    map_data <- full_data()
+    map_data <- map_data |>
+      sf::st_make_valid() |>
+      sf::st_zm(what = "ZM", drop = TRUE) |>
+      dplyr::filter(!sf::st_is_empty(geometry)) |>
+      dplyr::mutate(geom_type = sf::st_geometry_type(geometry)) |>
+      dplyr::filter(geom_type %in% c("POLYGON", "MULTIPOLYGON")) |>
+      dplyr::select(-geom_type)
+    if (nrow(map_data) == 0) {
+      return(
+        maplibre(style = carto_style("positron")) |>
+        add_control("No valid polygon geometry to display.", "top-left")
+      )
+    }
+    map_data <- map_data |>
+      dplyr::mutate(asunum = dplyr::na_if(asunum, 0L))
+    n_asu <- max(map_data$asunum, na.rm = TRUE)
+    n_asu <- ifelse(is.finite(n_asu), n_asu, 0L)
+    pal <- palette_logic(n_asu)
+    maplibre(style = carto_style("positron")) |>
+      fit_bounds(map_data, animate = FALSE) |>
+      add_fill_layer(
+        id                 = "basemap",
+        source             = map_data,
+        fill_color         = pal$fill,
+        fill_opacity       = 0.5,
+        fill_outline_color = "black"
+      )
+  })
+})
+
+observeEvent(input$th_combine, {
+  req(th_state())
+  withProgress(message = "Combining ASUs…", value = 0, {
+    st <- tract_hunter_combine_groups(th_state())
+  })
+  th_state(st)
+  res <- tract_hunter_finalize(st)
+  full_data(res$full_data  )   ; full_data_reset(res$full_data_reset)
+  asu_data(res$asu_data    )   ; asu_tracts(res$asu_tracts)
+  asu_summary(res$asu_summary) ; map_data_dbg(res$full_data)
+  output$asu <- renderTable( asu_summary(),digits = 3 )
+  maplibre_proxy("initial_map") %>% clear_layer("basemap")
+  output$initial_map <- renderMaplibre({
+    req(full_data())
+    map_data <- full_data()
+    map_data <- map_data |>
+      sf::st_make_valid() |>
+      sf::st_zm(what = "ZM", drop = TRUE) |>
+      dplyr::filter(!sf::st_is_empty(geometry)) |>
+      dplyr::mutate(geom_type = sf::st_geometry_type(geometry)) |>
+      dplyr::filter(geom_type %in% c("POLYGON", "MULTIPOLYGON")) |>
+      dplyr::select(-geom_type)
+    if (nrow(map_data) == 0) {
+      return(
+        maplibre(style = carto_style("positron")) |>
+        add_control("No valid polygon geometry to display.", "top-left")
+      )
+    }
+    map_data <- map_data |>
+      dplyr::mutate(asunum = dplyr::na_if(asunum, 0L))
+    n_asu <- max(map_data$asunum, na.rm = TRUE)
+    n_asu <- ifelse(is.finite(n_asu), n_asu, 0L)
+    pal <- palette_logic(n_asu)
+    maplibre(style = carto_style("positron")) |>
+      fit_bounds(map_data, animate = FALSE) |>
+      add_fill_layer(
+        id                 = "basemap",
+        source             = map_data,
+        fill_color         = pal$fill,
+        fill_opacity       = 0.5,
+        fill_outline_color = "black"
+      )
+  })
+})
 
 
 # ─────────────── DEBUG PANEL ───────────────


### PR DESCRIPTION
## Summary
- break `run_tract_hunter()` into helper stages (`seed`, `asu_pass`, `combine`, `finalize`)
- add buttons and reactive values for staged Tract Hunter workflow
- support new buttons in the flexdashboard

## Testing
- `R CMD build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b99f61810832a9890668d210ea149