### PR TITLE
Fix namespace exports

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,5 @@
 export(launch_ASUbuildR)
+export(run_asu_original)
 useDynLib(ASUbuildR, .registration = TRUE)
 importFrom(Rcpp, sourceCpp)
 


### PR DESCRIPTION
## Summary
- export `run_asu_original`

## Testing
- `R CMD build .` *(fails: vignette builder 'knitr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e99c0d0832a843ef97ccc0302af