### PR TITLE
Fix namespace exports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,8 @@ Imports:
     RColorBrewer,
     mapgl,
     rmarkdown,
+    rappdirs,
+    scales,
     stringr,
     sf,
     sfdep,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,16 @@
 export(launch_ASUbuildR)
+export(run_asu_original)
+export(tract_hunter_seed)
+export(tract_hunter_asu_pass)
+export(tract_hunter_combine_groups)
+export(tract_hunter_finalize)
 useDynLib(ASUbuildR, .registration = TRUE)
-importFrom(Rcpp, sourceCpp)
+
+# Additional imports used in the flexdashboard
+importFrom(rappdirs, user_cache_dir)
+importFrom(scales, comma)
+importFrom(utils, choose.dir)
+importFrom(tcltk, tk_choose.dir)
 
 # Core Shiny ecosystem - import everything to avoid issues
 import(shiny)

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -20,10 +20,7 @@ library(sfdep)
 library(tidyverse)
 library(readxl)
 library(Rcpp)
-
-sourceCpp("../../src/choose_best_neighbor.cpp")
-sourceCpp("../../src/build_edges.cpp")
-sourceCpp("../../src/choose_best_drop.cpp")
+library(ASUbuildR)
 
 ## ---- tigris cache ----------------------------------------------------
 ## put cached TIGER/Line ZIPs in a per-user cache folder that is always
@@ -42,15 +39,7 @@ options(tigris_cache_dir = cache_dir)
 # tell tigris to look there first before re‑downloading
 options(tigris_use_cache = TRUE)
 
-# ---- resolve paths from the project root ----------------------------
-# 'here()' always points at the directory that contains ASUbuildR.Rproj
-# no matter where this .Rmd lives.
-if (!requireNamespace("here", quietly = TRUE))
-  install.packages("here")
-
-library(here)          # <‑‑ add once
-source(here::here("R", "run_asu_original.r"))   # local = FALSE by default
-source(here::here("R", "run_tract_hunter.R"))
+# Use package functions directly
 
 # cache every tigris download automatically
 options(


### PR DESCRIPTION
## Summary
- export `run_asu_original`
- add missing imports used by the flexdashboard
- remove `sourceCpp` and `source()` calls so the dashboard runs from an installed package
- export Tract Hunter helpers

## Testing
- `apt-get update` *(fails: domain not allowed)*
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e99c0d0832a843ef97ccc0302af