### PR TITLE
Robust Python environment setup

### DIFF
--- a/R/launch_ASUbuildR.R
+++ b/R/launch_ASUbuildR.R
@@ -72,6 +72,14 @@ launch_ASUbuildR <- function(rmd_file = NULL,
     stop(paste("File", rmd_file, "not found. Please check the file path or ensure the .Rmd file is in the correct location."))
   }
 
+  # Ensure Python environment is ready before launching
+  if (!check_asu_python()) {
+    setup_asu_python()
+    if (!check_asu_python()) {
+      stop("Python environment setup failed", call. = FALSE)
+    }
+  }
+
   # Print status message
   cat("Starting ASU Flexdashboard...\n")
   cat("File:", rmd_file, "\n")

--- a/R/setup_asu_python.R
+++ b/R/setup_asu_python.R
@@ -38,7 +38,7 @@ setup_asu_python <- function(force = FALSE) {
   }
 
   # Create virtual environment
-  if (!dir.exists(venv_path) || force) {
+  if (force || !reticulate::virtualenv_exists(venv_path)) {
     message("Creating virtual environment...")
 
     reticulate::virtualenv_create(
@@ -77,8 +77,8 @@ setup_asu_python <- function(force = FALSE) {
 check_asu_python <- function() {
   venv_path <- file.path(rappdirs::user_data_dir("ASUbuildR"), "asu-cpsat-venv")
 
-  if (!dir.exists(venv_path)) {
-    message("Virtual environment not found.")
+  if (!reticulate::virtualenv_exists(venv_path)) {
+    message("Virtual environment not found or invalid.")
     message("Run setup_asu_python() to set up the Python environment.")
     return(FALSE)
   }

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -88,9 +88,11 @@ if (is_dev_mode) {
 # ── Use virtual environment & import Python module ───────────────────
 
 
-# Use the virtual environment we set up in the preamble
-venv_path <- file.path(rappdirs::user_data_dir("ASUbuildR"), "asu-cpsat-venv")
-reticulate::use_virtualenv(venv_path, required = TRUE)
+# Ensure the Python environment is available
+if (!ASUbuildR::check_asu_python()) {
+  ASUbuildR::setup_asu_python()
+  stopifnot(ASUbuildR::check_asu_python())
+}
 py_config()  # should now show the venv python
 
 # Import your solver module from the package's inst/python


### PR DESCRIPTION
## Summary
- ensure `setup_asu_python()` recreates env when missing and `check_asu_python()` validates virtualenv path
- verify Python environment before launching dashboard and during Rmd runtime

## Testing
- `R -q -e "sessionInfo()"`
- `R CMD build .` *(fails: vignette builder 'knitr' not found)*
- `R -q -e "install.packages('knitr', repos='https://cloud.r-project.org')"` *(fails: cannot open URL 'https://cloud.r-project.org/src/contrib/PACKAGES')*

------
https://chatgpt.com/codex/tasks/task_e_68a64e3597a8832a83b8e896a244d094