### PR TITLE
Gracefully handle missing Python virtualenv

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,6 @@
 export(launch_ASUbuildR)
+export(setup_asu_python)
+export(check_asu_python)
 useDynLib(ASUbuildR, .registration = TRUE)
 importFrom(Rcpp, sourceCpp)
 

--- a/R/setup_asu_python.R
+++ b/R/setup_asu_python.R
@@ -30,11 +30,15 @@ setup_asu_python <- function(force = FALSE) {
 
   # Check if Python is available, install if not
   if (!reticulate::py_available(initialize = FALSE)) {
-    message("Python not found. Installing Miniconda...")
-    message("This is a one-time installation and may take a few minutes...")
-
-    reticulate::install_miniconda()
-    message("Miniconda installed successfully!")
+    conda_path <- tryCatch(reticulate::miniconda_path(), error = function(e) "")
+    if (!nzchar(conda_path) || !dir.exists(conda_path)) {
+      message("Python not found. Installing Miniconda...")
+      message("This is a one-time installation and may take a few minutes...")
+      reticulate::install_miniconda()
+      message("Miniconda installed successfully!")
+    } else {
+      message("Using existing Miniconda installation at ", conda_path)
+    }
   }
 
   # Create virtual environment

--- a/R/setup_asu_python.R
+++ b/R/setup_asu_python.R
@@ -83,7 +83,25 @@ check_asu_python <- function() {
     return(FALSE)
   }
 
-  reticulate::use_virtualenv(venv_path, required = TRUE)
+  is_venv <- file.exists(file.path(venv_path, "pyvenv.cfg")) &&
+    (dir.exists(file.path(venv_path, "bin")) || dir.exists(file.path(venv_path, "Scripts")))
+
+  if (!is_venv) {
+    message("Directory exists but is not a valid Python virtual environment.")
+    message("Run setup_asu_python(force = TRUE) to recreate it.")
+    return(FALSE)
+  }
+
+  ok <- tryCatch({
+    reticulate::use_virtualenv(venv_path, required = TRUE)
+    TRUE
+  }, error = function(e) {
+    message("Failed to activate Python environment: ", e$message)
+    message("Run setup_asu_python(force = TRUE) to recreate it.")
+    FALSE
+  })
+
+  if (!ok) return(FALSE)
 
   required <- c("numpy", "pandas", "networkx", "ortools")
   available <- sapply(required, reticulate::py_module_available)

--- a/R/setup_asu_python.R
+++ b/R/setup_asu_python.R
@@ -28,7 +28,8 @@ setup_asu_python <- function(force = FALSE) {
     unlink(venv_path, recursive = TRUE, force = TRUE)
   }
 
-  # Check if Python is available, install if not
+  # Ensure Python interpreter is available
+  python <- NULL
   if (!reticulate::py_available(initialize = FALSE)) {
     conda_path <- tryCatch(reticulate::miniconda_path(), error = function(e) "")
     if (!nzchar(conda_path) || !dir.exists(conda_path)) {
@@ -39,6 +40,14 @@ setup_asu_python <- function(force = FALSE) {
     } else {
       message("Using existing Miniconda installation at ", conda_path)
     }
+    python <- reticulate::miniconda_python()
+    if (!file.exists(python)) {
+      message("Installing Python...")
+      reticulate::install_python()
+      python <- reticulate::miniconda_python()
+    }
+  } else {
+    python <- reticulate::py_config()$python
   }
 
   # Create virtual environment
@@ -47,6 +56,7 @@ setup_asu_python <- function(force = FALSE) {
 
     reticulate::virtualenv_create(
       envname = venv_path,
+      python = python,
       packages = c("numpy", "pandas", "networkx", "ortools==9.9.3963")
     )
 

--- a/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
+++ b/inst/shiny_app/ASU_Flexdashboard_mapgl.Rmd
@@ -89,8 +89,10 @@ if (is_dev_mode) {
 
 
 # Use the virtual environment we set up in the preamble
-venv_path <- file.path(rappdirs::user_data_dir("ASUbuildR"), "asu-cpsat-venv")
-reticulate::use_virtualenv(venv_path, required = TRUE)
+check_py <- if (exists("check_asu_python")) check_asu_python else ASUbuildR::check_asu_python
+if (!check_py()) {
+  stop("Python environment not properly configured. Run ASUbuildR::setup_asu_python().")
+}
 py_config()  # should now show the venv python
 
 # Import your solver module from the package's inst/python


### PR DESCRIPTION
## Summary
- Check that the configured Python directory is a real virtualenv before activation
- Fail early in the dashboard if the Python setup is incomplete, directing users to run `setup_asu_python()`
- Export Python setup helpers in the package namespace

## Testing
- `R CMD build .` *(fails: dependencies 'flexdashboard', 'mapgl', 'sfdep', 'tigris' are not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a7512f8460832abba4f7ad82e23115